### PR TITLE
add temporary dinopark roles expiring january 1

### DIFF
--- a/operations/cloudformation-templates/dinopark_ldap_hris_access.yml
+++ b/operations/cloudformation-templates/dinopark_ldap_hris_access.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "Roles for dinopark milestone 1 to access mozilla iam data in s3.  Expire on 01012019"
+Description: "IAM Role delegating rights from the infosec-prod AWS account to the mozilla-iam AWS account. Grants rights to access IAM data in infosec-prod S3. Expires on 2019-01-01"
 Parameters:
   ldapBucket:
     Type: String

--- a/operations/cloudformation-templates/dinopark_ldap_hris_access.yml
+++ b/operations/cloudformation-templates/dinopark_ldap_hris_access.yml
@@ -1,0 +1,55 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Roles for dinopark milestone 1 to access mozilla iam data in s3.  Expire on 01012019"
+Parameters:
+  ldapBucket:
+    Type: String
+    Default: 'cis-ldap2s3-publisher-data'
+  hrisBucket:
+    Type: String
+    Default: 'hris-data-prod.mozilla.com'
+  crossAccountId:
+    Type: String
+    Default: '320464205386'
+Resources:
+  ManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      Description: "Permissions for the assumeRole to be able to get objects from the ldap and hris buckets."
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "s3:getObject"
+              - "s3:ListObjects"
+              - "s3:ListBucket"
+            Resource:
+              - Fn::Join: ['', ['arn:aws:s3:::', {Ref: hrisBucket}, '/*' ]]
+              - Fn::Join: ['', ['arn:aws:s3:::', {Ref: hrisBucket}]]
+              - Fn::Join: ['', ['arn:aws:s3:::', {Ref: ldapBucket}, '/*' ]]
+              - Fn::Join: ['', ['arn:aws:s3:::', {Ref: ldapBucket}]]
+      ManagedPolicyName: "DinoParkS3AccessPermissions"
+  CrossAccountRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - Fn::Join: ['', ['arn:aws:iam::', {Ref: crossAccountId}, ':root']]
+            Action:
+              - "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                aws:PrincipalType: User
+              Bool:
+                aws:MultiFactorAuthPresent: 'true'
+              DateLessThan:
+                aws:CurrentTime: '2019-01-01T00:00:00Z'
+      ManagedPolicyArns:
+        - !Ref 'ManagedPolicy'
+      RoleName: "IAMTeamDataAccess"

--- a/operations/cloudformation-templates/dinopark_ldap_hris_assume_role.yml
+++ b/operations/cloudformation-templates/dinopark_ldap_hris_assume_role.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "Roles for dinopark milestone 1 to access mozilla iam data in s3.  Expire on 01012019"
+Description: "User group to be loaded in the mozilla-iam AWS account granting users rights to assume IAMTeamDataAccess role in infosec-prod AWS account to access IAM data in S3"
 Parameters:
   assumeRoleArn:
     Type: String

--- a/operations/cloudformation-templates/dinopark_ldap_hris_assume_role.yml
+++ b/operations/cloudformation-templates/dinopark_ldap_hris_assume_role.yml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Roles for dinopark milestone 1 to access mozilla iam data in s3.  Expire on 01012019"
+Parameters:
+  assumeRoleArn:
+    Type: String
+    Default: 'arn:aws:iam::371522382791:role/IAMTeamDataAccess'
+Resources:
+  DataAccessGroup:
+    Type: "AWS::IAM::Group"
+    Properties:
+      GroupName: "IAMTeamDataAccess"
+  IAMTeamCanAssumeRole:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      Description: Allow incident responders to assume role.
+      Path: /
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: Allow
+            Action: sts:AssumeRole
+            Resource:
+              - !Ref assumeRoleArn
+      Groups:
+        - "IAMTeamDataAccess"
+      ManagedPolicyName: "DinoParkDataAssumeRolePermission"

--- a/operations/cloudformation-templates/dinopark_ldap_hris_assume_role.yml
+++ b/operations/cloudformation-templates/dinopark_ldap_hris_assume_role.yml
@@ -12,7 +12,7 @@ Resources:
   IAMTeamCanAssumeRole:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      Description: Allow incident responders to assume role.
+      Description: Allow Mozilla IAM team data access members to assume role.
       Path: /
       PolicyDocument:
         Version: "2012-10-17"


### PR DESCRIPTION
This adds two templates:
* 1 to infosec creating a cross account assumable role that can read IAM data.
* 1 to IAM allowing members of a group to assume the role created by the previous template. 

Notes:

* role assumption requires MFA
* access will auto expire as per our working agreement 01012019