### PR TITLE
Add region constraints and change SNS topic ARN relative to local region

### DIFF
--- a/operations/cloudformation-templates/guardduty-member-account-role-mozilla.yml
+++ b/operations/cloudformation-templates/guardduty-member-account-role-mozilla.yml
@@ -7,31 +7,29 @@ Metadata:
     https://github.com/mozilla/guardduty-multi-account-manager/blob/master/cloudformation/guardduty-member-account-role.yml
     with Mozilla specific defaults added. This is available for use at
     https://s3.amazonaws.com/infosec-cloudformation-templates/guardduty-member-account-role-mozilla.yml
-  'AWS::CloudFormation::Interface':
-    ParameterGroups:
-    - Label:
-        default: "Configuration"
-      Parameters:
-      - MasterAccountPrincipal
-      - SNSArnForPublishingIAMRoleArn
-    ParameterLabels:
-      MasterAccountPrincipal:
-        default: Master Account IAM Principal
-      SNSArnForPublishingIAMRoleArn:
-        default: SNS Topic ARN to publish outputs to
-Parameters:
-  MasterAccountPrincipal:
-    Type: String
-    Default: arn:aws:iam::371522382791:root
-    AllowedPattern: '^arn:aws:iam::(?!123456789012)[0-9]*:root$'
-    ConstraintDescription: A root AWS account principal (other than arn:aws:iam::123456789012:root)
-    Description: 'The ARN of the AWS account of the GuardDuty master (Example : arn:aws:iam::123456789012:root)'
-  SNSArnForPublishingIAMRoleArn:
-    Type: String
-    Default: arn:aws:sns:us-west-2:371522382791:cloudformation-stack-emissions
-    AllowedPattern: '^arn:aws:sns:[^:]*:(?!123456789012)[0-9]*:.*$'
-    ConstraintDescription: An SNS Topic ARN (other than arn:aws:sns:us-west-2:123456789012:cloudformation-stack-emissions)
-    Description: 'The ARN of the SNS Topic to publish an event to with the new IAM Role ARN of the GuardDuty Invitation Acceptor (Example: arn:aws:sns:us-west-2:123456789012:cloudformation-stack-emissions)'
+    This template can only be deployed in us-west-2, us-east-1, us-west-1 and eu-west-1.
+Mappings:
+  Variables:
+    MasterAccount:
+      Principal: arn:aws:iam::371522382791:root
+    SNSTopicForPublishingIAMRoleArn:
+      Account: 371522382791
+      Topic: cloudformation-stack-emissions
+  TheRegionYouAreDeployingIn:
+    us-west-2:
+      WhatIsThisMapping: This constrains the regions in which you can deploy this template to only the regions listed in this mapping. This, for example, prevents deloying in ap-south-1
+      IsNotSupportedPleaseUseADifferentRegion: True
+    us-east-1:
+      WhatIsThisMapping: ''
+      IsNotSupportedPleaseUseADifferentRegion: True
+    us-west-1:
+      WhatIsThisMapping: ''
+      IsNotSupportedPleaseUseADifferentRegion: True
+    eu-west-1:
+      WhatIsThisMapping: ''
+      IsNotSupportedPleaseUseADifferentRegion: True
+Conditions:
+  RunningInAllowedRegion: !Equals [ !FindInMap [ TheRegionYouAreDeployingIn, !Ref 'AWS::Region', IsNotSupportedPleaseUseADifferentRegion ] , True ]
 Resources:
   GuardDutyInvitationAcceptorIAMRole:
     Type: AWS::IAM::Role
@@ -41,7 +39,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Ref MasterAccountPrincipal
+              AWS: !FindInMap [ Variables, MasterAccount, Principal ]
             Action: sts:AssumeRole
       Policies:
         - PolicyName: AllowAcceptingGuardDutyInvitation
@@ -67,9 +65,8 @@ Resources:
     Type: Custom::PublishIAMRoleArnsToSNS
     Version: '1.0'
     Properties:
-      ServiceToken: !Ref SNSArnForPublishingIAMRoleArn
+      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', !FindInMap [ Variables, SNSTopicForPublishingIAMRoleArn, Account ], !FindInMap [ Variables, SNSTopicForPublishingIAMRoleArn, Topic ] ] ]
       category: GuardDuty Multi Account Member Role
-      GuardDutyMemberAccountId: !Ref AWS::AccountId
       GuardDutyMemberAccountIAMRoleArn: !GetAtt GuardDutyInvitationAcceptorIAMRole.Arn
       GuardDutyMemberAccountIAMRoleName: !Ref GuardDutyInvitationAcceptorIAMRole
   CloudFormationLambdaIAMRole:


### PR DESCRIPTION
This changes the SNS topic ARN that the resulting IAM Role ARN is emitted
to from a fixed ARN to a relative ARN, relative to the region that the
GuardDuty member role is being deployed in.

Move parameters into mappings as we don't want users to be able to change
these values.

Remove GuardDutyMemberAccountId emitted attribute as this is already
present in the record in DynamoDB
Add region constraints and change SNS topic ARN relative to local region

This changes the SNS topic ARN that the resulting IAM Role ARN is emitted
to from a fixed ARN to a relative ARN, relative to the region that the
GuardDuty member role is being deployed in.

Move parameters into mappings as we don't want users to be able to change
these values.

Remove GuardDutyMemberAccountId emitted attribute as this is already
present in the record in DynamoDB