### PR TITLE
Remove mozdef-prod user's rights to assume security audit roles

### DIFF
--- a/operations/cloudformation-templates/mozdef_user/mozdef_user.json
+++ b/operations/cloudformation-templates/mozdef_user/mozdef_user.json
@@ -183,11 +183,6 @@
               "Effect": "Allow",
               "Action": "sts:GetSessionToken",
               "Resource": "*"
-            },
-            {
-              "Effect": "Allow",
-              "Action": "sts:AssumeRole",
-              "Resource": "arn:aws:iam::*:role/*-InfosecSecurityAuditRole-*"
             }
           ]
         }


### PR DESCRIPTION
This is no longer needed to fetch CloudTrail logs
[Bug 1406214](https://bugzilla.mozilla.org/show_bug.cgi?id=1406214)