### PR TITLE
 Add new dev S3 bucket for Auth0 rule assets 

### DIFF
--- a/operations/cloudformation-templates/create_infosec_s3_buckets_us-east-1.yml
+++ b/operations/cloudformation-templates/create_infosec_s3_buckets_us-east-1.yml
@@ -2,12 +2,14 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Create Enterprise Information Security S3 Buckets in us-east-1.
 Metadata:
   Source: https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/create_infosec_s3_buckets_us-east-1.yml
-Mappings:
-  TheRegionYouAreDeployingIn:
-    us-east-1:
-      IsNotSupportedPleaseUseADifferentRegion: True
-Conditions:
-  RunningInAllowedRegion: !Equals [ !FindInMap [ TheRegionYouAreDeployingIn, !Ref 'AWS::Region', IsNotSupportedPleaseUseADifferentRegion ] , True ]
+Rules:
+  CorrectRegionAndAccount:
+    RuleCondition: !Equals [ '1', '1' ]
+    Assertions:
+      - Assert: !Equals [ !Ref 'AWS::Region', us-east-1 ]
+        AssertDescription: This template deploys us-east-1 resources and must be depoyed only in us-east-1
+      - Assert: !Equals [ !Ref 'AWS::AccountId', '371522382791' ]
+        AssertDescription: This template deploys infosec-dev resources and must be depoyed only in infosec-prod 371522382791 AWS account
 Resources:
   InfosecCloudFormationTemplates:
     Type: AWS::S3::Bucket

--- a/operations/cloudformation-templates/create_infosec_s3_buckets_us-west-2.yml
+++ b/operations/cloudformation-templates/create_infosec_s3_buckets_us-west-2.yml
@@ -2,12 +2,14 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Create Enterprise Information Security S3 Buckets in us-west-2.
 Metadata:
   Source: https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/create_infosec_s3_buckets_us-west-2.yml
-Mappings:
-  TheRegionYouAreDeployingIn:
-    us-west-2:
-      IsNotSupportedPleaseUseADifferentRegion: True
-Conditions:
-  RunningInAllowedRegion: !Equals [ !FindInMap [ TheRegionYouAreDeployingIn, !Ref 'AWS::Region', IsNotSupportedPleaseUseADifferentRegion ] , True ]
+Rules:
+  CorrectRegionAndAccount:
+    RuleCondition: !Equals [ '1', '1' ]
+    Assertions:
+      - Assert: !Equals [ !Ref 'AWS::Region', us-west-2 ]
+        AssertDescription: This template deploys us-west-2 resources and must be depoyed only in us-west-2
+      - Assert: !Equals [ !Ref 'AWS::AccountId', '371522382791' ]
+        AssertDescription: This template deploys infosec-dev resources and must be depoyed only in infosec-prod 371522382791 AWS account
 Resources:
   InfosecLambdaUsWest2:
     Type: AWS::S3::Bucket

--- a/operations/cloudformation-templates/infosec_dev_s3_buckets_us-east-1.yml
+++ b/operations/cloudformation-templates/infosec_dev_s3_buckets_us-east-1.yml
@@ -2,12 +2,14 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Create Enterprise Information Security Dev S3 Buckets in us-east-1.
 Metadata:
   Source: https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/infosec_dev_s3_buckets_us-east-1.yml
-Mappings:
-  TheRegionYouAreDeployingIn:
-    us-east-1:
-      IsNotSupportedPleaseUseADifferentRegion: True
-Conditions:
-  RunningInAllowedRegion: !Equals [ !FindInMap [ TheRegionYouAreDeployingIn, !Ref 'AWS::Region', IsNotSupportedPleaseUseADifferentRegion ] , True ]
+Rules:
+  CorrectRegionAndAccount:
+    RuleCondition: !Equals [ '1', '1' ]
+    Assertions:
+      - Assert: !Equals [ !Ref 'AWS::Region', us-east-1 ]
+        AssertDescription: This template deploys us-east-1 resources and must be depoyed only in us-east-1
+      - Assert: !Equals [ !Ref 'AWS::AccountId', '656532927350' ]
+        AssertDescription: This template deploys infosec-dev resources and must be depoyed only in infosec-dev 656532927350 AWS account
 Resources:
   PublicUsEast1:
     Type: AWS::S3::Bucket

--- a/operations/cloudformation-templates/infosec_dev_s3_buckets_us-west-2.yml
+++ b/operations/cloudformation-templates/infosec_dev_s3_buckets_us-west-2.yml
@@ -2,12 +2,14 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Create Enterprise Information Security Dev S3 Buckets in us-west-2.
 Metadata:
   Source: https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/infosec_dev_s3_buckets_us-west-2.yml
-Mappings:
-  TheRegionYouAreDeployingIn:
-    us-west-2:
-      IsNotSupportedPleaseUseADifferentRegion: True
-Conditions:
-  RunningInAllowedRegion: !Equals [ !FindInMap [ TheRegionYouAreDeployingIn, !Ref 'AWS::Region', IsNotSupportedPleaseUseADifferentRegion ] , True ]
+Rules:
+  CorrectRegionAndAccount:
+    RuleCondition: !Equals [ '1', '1' ]
+    Assertions:
+      - Assert: !Equals [ !Ref 'AWS::Region', us-west-2 ]
+        AssertDescription: This template deploys us-west-2 resources and must be depoyed only in us-west-2
+      - Assert: !Equals [ !Ref 'AWS::AccountId', '656532927350' ]
+        AssertDescription: This template deploys infosec-dev resources and must be depoyed only in infosec-dev 656532927350 AWS account
 Resources:
   PublicUsWest2:
     Type: AWS::S3::Bucket

--- a/operations/cloudformation-templates/infosec_dev_s3_buckets_us-west-2.yml
+++ b/operations/cloudformation-templates/infosec_dev_s3_buckets_us-west-2.yml
@@ -68,3 +68,10 @@ Resources:
                   - s3:ReplicateTags
                   - s3:GetObjectVersionTagging
                 Resource: arn:aws:s3:::public.us-east-1.security.allizom.org/*
+  MozillaInfosecAuth0RuleAssetsDevBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: mozilla-infosec-auth0-dev-rule-assets
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true


### PR DESCRIPTION
Also

Add template constraints on regions and accounts

Prevent deploying the templates in the wrong account or region
This takes advantage of the new "Rules" feature in CloudFormation
and gets rid of the Mappings Condition hack we were using before