### PR TITLE
Add OIDC identity provider

### DIFF
--- a/operations/cloudformation-templates/functions/README.md
+++ b/operations/cloudformation-templates/functions/README.md
@@ -1,0 +1,3 @@
+This directory contains copies of Lambda functions which are embedded in
+CloudFormation templates in the parent directory. These copies make it easier
+to edit the code in an IDE then later paste it into the template.

--- a/operations/cloudformation-templates/functions/oidc_identity_provider.py
+++ b/operations/cloudformation-templates/functions/oidc_identity_provider.py
@@ -1,0 +1,90 @@
+import json
+import boto3
+from botocore.vendored import requests
+from botocore.exceptions import ClientError
+
+iam = boto3.client("iam")
+
+
+def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
+  print(event['ResponseURL'])
+  responseBody = {
+    'Status': 'SUCCESS' if responseStatus else 'FAILED',
+    'Reason': 'See the details in CloudWatch Log Stream: ' + context.log_stream_name,
+    'PhysicalResourceId': physicalResourceId or context.log_stream_name,
+    'StackId': event['StackId'], 'RequestId': event['RequestId'],
+    'LogicalResourceId': event['LogicalResourceId'], 'NoEcho': noEcho, 'Data': responseData
+  }
+  json_responseBody = json.dumps(responseBody)
+  print("Response body:\n" + json_responseBody)
+  headers = {'content-type' : '', 'content-length': str(len(json_responseBody))}
+  try:
+    response = requests.put(event['ResponseURL'], data=json_responseBody, headers=headers)
+    print("Status code: " + response.reason)
+  except Exception as e:
+    print("send(..) failed executing requests.put(..): " + str(e))
+
+
+def create_provider(url, client_id_list, thumbprint_list):
+  try:
+    response = iam.create_open_id_connect_provider(Url=url, ClientIDList=client_id_list, ThumbprintList=thumbprint_list)
+    return True, response['OpenIDConnectProviderArn']
+  except Exception as e:
+    return False, "Cannot create OIDC provider: " + str(e)
+
+
+def delete_provider(arn):
+  try:
+    iam.delete_open_id_connect_provider(OpenIDConnectProviderArn=arn)
+    return True, "OIDC provider with ARN " + arn + " deleted"
+  except ClientError as e:
+    if e.response['Error']['Code'] == "NoSuchEntity":
+      return True, "OIDC provider with ARN {} does not exist, deletion succeeded".format(arn)
+    else:
+      return False, "Cannot delete OIDC provider with ARN {} : {}".format(arn, str(e))
+  except Exception as e:
+    return False, "Cannot delete OIDC provider with ARN " + arn + ": " + str(e)
+
+
+def update_provider(arn, client_id_list, thumbprint_list):
+  try:
+    response = iam.get_open_id_connect_provider(OpenIDConnectProviderArn=arn)
+    deleted_client_ids = set(response['ClientIDList']) - set(client_id_list)
+    added_client_ids = set(client_id_list) - set(response['ClientIDList'])
+    if set(thumbprint_list) ^ set(response['ThumbprintList']):
+      iam.update_open_id_connect_provider_thumbprint(OpenIDConnectProviderArn=arn, ThumbprintList=thumbprint_list)
+    for client_id in added_client_ids:
+      iam.add_client_id_to_open_id_connect_provider(OpenIDConnectProviderArn=arn, ClientID=client_id)
+    for client_id in deleted_client_ids:
+      iam.remove_client_id_from_open_id_connect_provider(OpenIDConnectProviderArn=arn, ClientID=client_id)
+    return True, "OIDC provider " + arn + " updated"
+  except Exception as e:
+    return False, "Cannot update OIDC provider " + arn + ": " + str(e)
+
+
+def lambda_handler(event, context):
+  url = event['ResourceProperties']['Url']
+  def split_list(k):
+    return [x.strip() for x in event['ResourceProperties'].get(k, '').split(',')]
+  client_id_list = split_list('ClientIDList')
+  thumbprint_list = split_list('ThumbprintList')
+
+  arn_format = "arn:aws:iam::${AWS::AccountId}:oidc-provider/{}"
+  arn = arn_format.format(url[8:])
+  if event['RequestType'] == 'Create':
+    result, arn = create_provider(url, client_id_list, thumbprint_list)
+    reason = "Creation succeeded"
+  elif event['RequestType'] == 'Update':
+    if event['OldResourceProperties']['Url'] != url:
+        result, reason = delete_provider(arn)
+        if result:
+          result, reason_create = create_provider(url, client_id_list, thumbprint_list)
+          if result:
+            reason = ' '.join([reason, reason_create])
+    else:
+      result, reason = update_provider(arn, client_id_list, thumbprint_list)
+  elif event['RequestType'] == 'Delete':
+    result, reason = delete_provider(arn)
+  else:
+    result, reason = False, "Unknown operation: " + event['RequestType']
+  send(event, context, result, {'Reason': reason, 'event': event}, arn)

--- a/operations/cloudformation-templates/oidc_identity_provider.yml
+++ b/operations/cloudformation-templates/oidc_identity_provider.yml
@@ -1,0 +1,157 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: OIDC identity provider
+Metadata:
+  Source: https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/oidc_identity_provider.yml
+Parameters:
+  Url:
+    Type: String
+    Description: The URL of the identity provider. The URL must begin with https:// and should correspond to the iss claim in the provider's OpenID Connect ID tokens
+    AllowedPattern: https://.*
+    ConstraintDescription: The URL must begin with https://
+  ClientIDList:
+    Type: String
+    Description: A comma delimited list of client IDs (also known as audiences)
+  ThumbprintList:
+    Type: String
+    Description: A comma delimited list list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificates (also known as CA Thumbprints)
+Resources:
+  IdentityProvider:
+    Type: Custom::IdentityProvider
+    Properties:
+      ServiceToken: !GetAtt IdentityProviderCreatorFunction.Arn
+      Region: !Ref "AWS::Region"
+      Url: !Ref Url
+      ClientIDList: !Ref ClientIDList
+      ThumbprintList: !Ref ThumbprintList
+  IdentityProviderCreatorFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python2.7
+      Handler: index.lambda_handler
+      MemorySize: 128
+      Role: !GetAtt IdentityProviderCreatorRole.Arn
+      Timeout: 30
+      Code:
+        ZipFile: !Sub |
+          import json
+          import boto3
+          from botocore.vendored import requests
+          from botocore.exceptions import ClientError
+
+          iam = boto3.client("iam")
+
+
+          def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
+            print(event['ResponseURL'])
+            responseBody = {
+              'Status': 'SUCCESS' if responseStatus else 'FAILED',
+              'Reason': 'See the details in CloudWatch Log Stream: ' + context.log_stream_name,
+              'PhysicalResourceId': physicalResourceId or context.log_stream_name,
+              'StackId': event['StackId'], 'RequestId': event['RequestId'],
+              'LogicalResourceId': event['LogicalResourceId'], 'NoEcho': noEcho, 'Data': responseData
+            }
+            json_responseBody = json.dumps(responseBody)
+            print("Response body:\n" + json_responseBody)
+            headers = {'content-type' : '', 'content-length': str(len(json_responseBody))}
+            try:
+              response = requests.put(event['ResponseURL'], data=json_responseBody, headers=headers)
+              print("Status code: " + response.reason)
+            except Exception as e:
+              print("send(..) failed executing requests.put(..): " + str(e))
+
+
+          def create_provider(url, client_id_list, thumbprint_list):
+            try:
+              response = iam.create_open_id_connect_provider(Url=url, ClientIDList=client_id_list, ThumbprintList=thumbprint_list)
+              return True, response['OpenIDConnectProviderArn']
+            except Exception as e:
+              return False, "Cannot create OIDC provider: " + str(e)
+
+
+          def delete_provider(arn):
+            try:
+              iam.delete_open_id_connect_provider(OpenIDConnectProviderArn=arn)
+              return True, "OIDC provider with ARN " + arn + " deleted"
+            except ClientError as e:
+              if e.response['Error']['Code'] == "NoSuchEntity":
+                return True, "OIDC provider with ARN {} does not exist, deletion succeeded".format(arn)
+              else:
+                return False, "Cannot delete OIDC provider with ARN {} : {}".format(arn, str(e))
+            except Exception as e:
+              return False, "Cannot delete OIDC provider with ARN " + arn + ": " + str(e)
+
+
+          def update_provider(arn, client_id_list, thumbprint_list):
+            try:
+              response = iam.get_open_id_connect_provider(OpenIDConnectProviderArn=arn)
+              deleted_client_ids = set(response['ClientIDList']) - set(client_id_list)
+              added_client_ids = set(client_id_list) - set(response['ClientIDList'])
+              if set(thumbprint_list) ^ set(response['ThumbprintList']):
+                iam.update_open_id_connect_provider_thumbprint(OpenIDConnectProviderArn=arn, ThumbprintList=thumbprint_list)
+              for client_id in added_client_ids:
+                iam.add_client_id_to_open_id_connect_provider(OpenIDConnectProviderArn=arn, ClientID=client_id)
+              for client_id in deleted_client_ids:
+                iam.remove_client_id_from_open_id_connect_provider(OpenIDConnectProviderArn=arn, ClientID=client_id)
+              return True, "OIDC provider " + arn + " updated"
+            except Exception as e:
+              return False, "Cannot update OIDC provider " + arn + ": " + str(e)
+
+
+          def lambda_handler(event, context):
+            url = event['ResourceProperties']['Url']
+            def split_list(k):
+              return [x.strip() for x in event['ResourceProperties'].get(k, '').split(',')]
+            client_id_list = split_list('ClientIDList')
+            thumbprint_list = split_list('ThumbprintList')
+
+            arn_format = "arn:aws:iam::${AWS::AccountId}:oidc-provider/{}"
+            arn = arn_format.format(url[8:])
+            if event['RequestType'] == 'Create':
+              result, arn = create_provider(url, client_id_list, thumbprint_list)
+              reason = "Creation succeeded"
+            elif event['RequestType'] == 'Update':
+              if event['OldResourceProperties']['Url'] != url:
+                  result, reason = delete_provider(arn)
+                  if result:
+                    result, reason_create = create_provider(url, client_id_list, thumbprint_list)
+                    if result:
+                      reason = ' '.join([reason, reason_create])
+              else:
+                result, reason = update_provider(arn, client_id_list, thumbprint_list)
+            elif event['RequestType'] == 'Delete':
+              result, reason = delete_provider(arn)
+            else:
+              result, reason = False, "Unknown operation: " + event['RequestType']
+            send(event, context, result, {'Reason': reason, 'event': event}, arn)
+  IdentityProviderCreatorRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: ManageOIDCProvider
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:GetOpenIDConnectProvider
+                  - iam:CreateOpenIDConnectProvider
+                  - iam:AddClientIDToOpenIDConnectProvider
+                  - iam:RemoveClientIDFromOpenIDConnectProvider
+                  - iam:UpdateOpenIDConnectProviderThumbprint
+                  - iam:DeleteOpenIDConnectProvider
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"


### PR DESCRIPTION
This isn't perfect but it's what fits in 4096 characters (the CloudFormation limit for embedded lambda). The Create Update and Delete aren't truly idempotent.

The way to do this if you don't mind having the Lambda not embedded would be to use something like [customer-resource-helper](https://github.com/aws-cloudformation/custom-resource-helper) and make each one idempotent