### PR TITLE
chore(python): Upgrade python lambdas to support lambda runtime

### DIFF
--- a/operations/aws-security-roles/guardduty-member-account-role-mozilla.yml
+++ b/operations/aws-security-roles/guardduty-member-account-role-mozilla.yml
@@ -130,7 +130,7 @@ Resources:
                     event, context, cfnresponse.SUCCESS, {'RoleCreated': created},
                     physical_id)
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role: !GetAtt CloudFormationLambdaIAMRole.Arn
       Timeout: 20
   CreateGuardDutyServiceLinkedRole:

--- a/operations/aws-security-roles/infosec-security-audit-incident-response-guardduty-roles-cloudformation.yml
+++ b/operations/aws-security-roles/infosec-security-audit-incident-response-guardduty-roles-cloudformation.yml
@@ -294,7 +294,7 @@ Resources:
                     event, context, cfnresponse.SUCCESS, {'RoleCreated': created},
                     physical_id)
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role: !GetAtt CloudFormationLambdaIAMRole.Arn
       Timeout: 20
   CreateGuardDutyServiceLinkedRole:


### PR DESCRIPTION
We got an alert from Amazon about Python 3.6 EOL for Lambas in the Pocket account. Traced it back to here.