### PR TITLE
Expand security auditor role to be able to query for more Arns

### DIFF
--- a/operations/cloudformation-templates/infosec-prod_oidc_federated_roles.yaml
+++ b/operations/cloudformation-templates/infosec-prod_oidc_federated_roles.yaml
@@ -111,6 +111,10 @@ Resources:
                   - category
                   - SecurityAuditIAMRoleArn
                   - SecurityAuditIAMRoleName
+                  - InfosecIncidentResponseRoleArn
+                  - InfosecIncidentResponseRoleName
+                  - BreakGlassSNSTopicArn
+                  - BreakGlassSNSTopicName
               StringEqualsIfExists:
                 "dynamodb:Select": SPECIFIC_ATTRIBUTES
           - Effect: Allow


### PR DESCRIPTION
Previously the `MAWS-SecurityAuditor` could only query the cloudformation-stack-emissions to get the ARNs of the security auditor roles.

This expands that so that the user can also query for the incident response roles as well as the break glass SNS topic Arns