### PR TITLE
Add a few more permissions to the new cloudformation stack emission reader

### DIFF
--- a/operations/cloudformation-templates/cloudformation-stack-emissions-reader-role.yml
+++ b/operations/cloudformation-templates/cloudformation-stack-emissions-reader-role.yml
@@ -49,6 +49,11 @@ Resources:
                   - InfosecIncidentResponseRoleName
                   - BreakGlassSNSTopicArn
                   - BreakGlassSNSTopicName
+                  - stack-id
+                  - stack-name
+                  - region
+                  - last-updated
+                  - logical-resource-id
               StringEqualsIfExists:
                 "dynamodb:Select": SPECIFIC_ATTRIBUTES
       PolicyName: CloudFormationStackEmissionReader


### PR DESCRIPTION
We'll need to be able to read these additional fields in the table.