### PR TITLE
Update Deprecated Security Roles

### DIFF
--- a/operations/aws-security-roles/eis-security-audit-trusting-role.yml
+++ b/operations/aws-security-roles/eis-security-audit-trusting-role.yml
@@ -39,12 +39,19 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/SecurityAudit
       Policies:
-        - PolicyName: MozillaSecurityAuditAugmentation
+        - PolicyName: PreMigrationAWSPortalViewAccess
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Action:
                   - aws-portal:View*
+                Effect: Allow
+                Resource: '*'
+        - PolicyName: MozillaSecurityAuditAugmentation
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
                   - awsbillingconsole:View*
                   - cloudformation:Describe*
                   - cloudformation:Get*
@@ -66,6 +73,66 @@ Resources:
                   - ses:List*
                   - sqs:Get*
                   - storagegateway:Describe*
+                Effect: Allow
+                Resource: '*'
+        - PolicyName: UpdatedPoliciesForAWSPortalViewAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - account:GetAccountInformation
+                  - account:GetAlternateContact
+                  - account:GetChallengeQuestions
+                  - account:GetContactInformation
+                  - billing:GetBillingData
+                  - billing:GetBillingDetails
+                  - billing:GetBillingNotifications
+                  - billing:GetBillingPreferences
+                  - billing:GetContractInformation
+                  - billing:GetCredits
+                  - billing:GetIAMAccessPreference
+                  - billing:GetSellerOfRecord
+                  - billing:ListBillingViews
+                  - ce:DescribeNotificationSubscription
+                  - ce:DescribeReport
+                  - ce:GetAnomalies
+                  - ce:GetAnomalyMonitors
+                  - ce:GetAnomalySubscriptions
+                  - ce:GetCostAndUsage
+                  - ce:GetCostAndUsageWithResources
+                  - ce:GetCostCategories
+                  - ce:GetCostForecast
+                  - ce:GetDimensionValues
+                  - ce:GetPreferences
+                  - ce:GetReservationCoverage
+                  - ce:GetReservationPurchaseRecommendation
+                  - ce:GetReservationUtilization
+                  - ce:GetRightsizingRecommendation
+                  - ce:GetSavingsPlansCoverage
+                  - ce:GetSavingsPlansPurchaseRecommendation
+                  - ce:GetSavingsPlansUtilization
+                  - ce:GetSavingsPlansUtilizationDetails
+                  - ce:GetTags
+                  - ce:GetUsageForecast
+                  - ce:ListCostAllocationTags
+                  - ce:ListSavingsPlansPurchaseRecommendationGeneration
+                  - consolidatedbilling:GetAccountBillingRole
+                  - consolidatedbilling:ListLinkedAccounts
+                  - cur:GetClassicReport
+                  - cur:GetClassicReportPreferences
+                  - cur:GetUsageReport
+                  - cur:ValidateReportDestination
+                  - freetier:GetFreeTierAlertPreference
+                  - freetier:GetFreeTierUsage
+                  - invoicing:GetInvoiceEmailDeliveryPreferences
+                  - invoicing:GetInvoicePDF
+                  - invoicing:ListInvoiceSummaries
+                  - payments:GetPaymentInstrument
+                  - payments:GetPaymentStatus
+                  - payments:ListPaymentPreferences
+                  - tax:GetTaxInheritance
+                  - tax:GetTaxRegistrationDocument
+                  - tax:ListTaxRegistrations
                 Effect: Allow
                 Resource: '*'
   PublishInfosecSecurityAuditRoleArnToSNS:

--- a/operations/aws-security-roles/infosec-security-audit-incident-response-guardduty-roles-cloudformation.yml
+++ b/operations/aws-security-roles/infosec-security-audit-incident-response-guardduty-roles-cloudformation.yml
@@ -51,12 +51,19 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/SecurityAudit
       Policies:
-        - PolicyName: MozillaSecurityAuditAugmentation
+        - PolicyName: PreMigrationAWSPortalViewAccess
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Action:
                   - aws-portal:View*
+                Effect: Allow
+                Resource: '*'
+        - PolicyName: MozillaSecurityAuditAugmentation
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
                   - awsbillingconsole:View*
                   - cloudformation:Describe*
                   - cloudformation:Get*
@@ -78,6 +85,66 @@ Resources:
                   - ses:List*
                   - sqs:Get*
                   - storagegateway:Describe*
+                Effect: Allow
+                Resource: '*'
+        - PolicyName: UpdatedPoliciesForAWSPortalViewAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - account:GetAccountInformation
+                  - account:GetAlternateContact
+                  - account:GetChallengeQuestions
+                  - account:GetContactInformation
+                  - billing:GetBillingData
+                  - billing:GetBillingDetails
+                  - billing:GetBillingNotifications
+                  - billing:GetBillingPreferences
+                  - billing:GetContractInformation
+                  - billing:GetCredits
+                  - billing:GetIAMAccessPreference
+                  - billing:GetSellerOfRecord
+                  - billing:ListBillingViews
+                  - ce:DescribeNotificationSubscription
+                  - ce:DescribeReport
+                  - ce:GetAnomalies
+                  - ce:GetAnomalyMonitors
+                  - ce:GetAnomalySubscriptions
+                  - ce:GetCostAndUsage
+                  - ce:GetCostAndUsageWithResources
+                  - ce:GetCostCategories
+                  - ce:GetCostForecast
+                  - ce:GetDimensionValues
+                  - ce:GetPreferences
+                  - ce:GetReservationCoverage
+                  - ce:GetReservationPurchaseRecommendation
+                  - ce:GetReservationUtilization
+                  - ce:GetRightsizingRecommendation
+                  - ce:GetSavingsPlansCoverage
+                  - ce:GetSavingsPlansPurchaseRecommendation
+                  - ce:GetSavingsPlansUtilization
+                  - ce:GetSavingsPlansUtilizationDetails
+                  - ce:GetTags
+                  - ce:GetUsageForecast
+                  - ce:ListCostAllocationTags
+                  - ce:ListSavingsPlansPurchaseRecommendationGeneration
+                  - consolidatedbilling:GetAccountBillingRole
+                  - consolidatedbilling:ListLinkedAccounts
+                  - cur:GetClassicReport
+                  - cur:GetClassicReportPreferences
+                  - cur:GetUsageReport
+                  - cur:ValidateReportDestination
+                  - freetier:GetFreeTierAlertPreference
+                  - freetier:GetFreeTierUsage
+                  - invoicing:GetInvoiceEmailDeliveryPreferences
+                  - invoicing:GetInvoicePDF
+                  - invoicing:ListInvoiceSummaries
+                  - payments:GetPaymentInstrument
+                  - payments:GetPaymentStatus
+                  - payments:ListPaymentPreferences
+                  - tax:GetTaxInheritance
+                  - tax:GetTaxRegistrationDocument
+                  - tax:ListTaxRegistrations
                 Effect: Allow
                 Resource: '*'
   InfosecIncidentResponseRole:


### PR DESCRIPTION
# Description
[SE-3577](https://mozilla-hub.atlassian.net/jira/software/c/projects/SE/issues/SE-3577): Updated InfosecSecurityAuditRole policies to account for deprecated "aws-portal:View*" action.

## Details
AWS is deprecating several actions including aws-portal:View*. This PR will address this by replacing the action with the recommended changes

https://aws.amazon.com/blogs/aws-cloud-financial-management/changes-to-aws-billing-cost-management-and-account-consoles-permissions/

## Equivalent New IAM Policy Actions
The [AWS Affected Policy Console](https://us-east-1.console.aws.amazon.com/poliden/home?region=us-east-1#/) was used to determine the new actions that will replace aws-portal:View*

The findings are attached: [recommendations.json](https://github.com/mozilla/security/files/13532638/recommendations.json)

